### PR TITLE
enable to watch templates defined by templateUrl

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,14 +1,14 @@
-import {CompilerConfig, CompilerUnit, CompilerUnitTransformer, SourceTransformation} from "./public_api";
+import {CompilerConfig, CompilerUnit, CompilerUnitTransformer, SourceTransformation, TranspilerApi} from "./public_api";
 import {TSTranspiler} from "./transpiler";
 import {replaceRange} from "./util";
 import {TSTranspilerData, TSTranspilerDataConfig} from "./transpiler/model";
 
-export function compile(unit: CompilerUnit, config: CompilerConfig): string {
+export function compile(unit: CompilerUnit, config: CompilerConfig, api: TranspilerApi): string {
     assertCompilerInput(unit, config);
     return config.transformers
         .reduce(
             (context, transformer) => context.transform(transformer),
-            CompilerContext.create(unit, new TSTranspilerDataConfig(config.template))
+            CompilerContext.create(unit, api, new TSTranspilerDataConfig(config.template))
         )
         .execute();
 }
@@ -46,7 +46,7 @@ class CompilerContext {
             );
     }
 
-    static create(unit: CompilerUnit, config: TSTranspilerDataConfig): CompilerContext {
-        return new CompilerContext(new TSTranspiler().transpile(unit, config));
+    static create(unit: CompilerUnit, api: TranspilerApi, config: TSTranspilerDataConfig): CompilerContext {
+        return new CompilerContext(new TSTranspiler().transpile(unit, api, config));
     }
 }

--- a/packages/compiler/src/public_api.ts
+++ b/packages/compiler/src/public_api.ts
@@ -1,6 +1,6 @@
 import {TSTranspilerData} from "./transpiler/model";
 
-export * from './transpiler/public_api';
+export * from "./transpiler/public_api";
 
 export enum SupportedDecorators {
     Component = 'Component',
@@ -21,6 +21,7 @@ export interface CompilerUnit {
     name: string;
     path: string;
     content: string;
+    templateUrlPath?: string;
 }
 
 export interface CompilerUnitTransformer {

--- a/packages/compiler/src/template/template-loader-component-transpiler.ts
+++ b/packages/compiler/src/template/template-loader-component-transpiler.ts
@@ -8,10 +8,12 @@ import {SupportedComponentProperties, ValueObject} from "../public_api";
 export class TemplateLoaderComponentTranspiler implements ComponentTranspiler {
     transpile(config: ValueObject, context: TemplateTranspilerContext): ValueObject {
         if (context.config.template.load && objectHasProperty(config, SupportedComponentProperties.templateUrl)) {
+            const templateFileName: string = objectGetPropertyText(config, SupportedComponentProperties.templateUrl);
+            context.api.addDependency(resolveTemplatePath(context.path, templateFileName));
             return addOrUpdateObjectProperty(
                 removeObjectProperty(config, SupportedComponentProperties.templateUrl),
                 SupportedComponentProperties.template,
-                '`' + loadHtmlTemplate(context.path, objectGetPropertyText(config, SupportedComponentProperties.templateUrl)) + '`',
+                '`' + loadHtmlTemplate(context.path, templateFileName) + '`',
                 ts.SyntaxKind.StringLiteral
             );
         }

--- a/packages/compiler/src/template/template-transpiler-context.ts
+++ b/packages/compiler/src/template/template-transpiler-context.ts
@@ -1,12 +1,13 @@
-import {TSTranspilerClassData, TSTranspilerData, TSTranspilerDataConfig} from "../transpiler/model";
+import {TranspilerApi, TSTranspilerClassData, TSTranspilerData, TSTranspilerDataConfig} from "..";
 
 export class TemplateTranspilerContext {
     constructor(readonly clazz: TSTranspilerClassData,
                 readonly path: string,
+                readonly api: TranspilerApi,
                 readonly config: TSTranspilerDataConfig) {
     }
 
     static create(clazz: TSTranspilerClassData, data: TSTranspilerData): TemplateTranspilerContext {
-        return new TemplateTranspilerContext(clazz, data.path, data.config);
+        return new TemplateTranspilerContext(clazz, data.path, data.api, data.config);
     }
 }

--- a/packages/compiler/src/transpiler.ts
+++ b/packages/compiler/src/transpiler.ts
@@ -1,9 +1,10 @@
 import * as ts from 'typescript';
-import {CompilerUnit} from "./public_api";
+import {CompilerUnit, TranspilerApi} from "./public_api";
 import {createProgram} from "./transpiler/util";
 import {createTranspilerOptions} from "./transpiler/options";
 import {
-    ClassMethodData, ClassPropertyData,
+    ClassMethodData,
+    ClassPropertyData,
     ConstructorParameterDecorator,
     DecoratorData,
     PropertyDecoratorData,
@@ -17,7 +18,7 @@ export class TSTranspiler {
 
     private dataBuilder: TSTranspilerDataBuilder = new TSTranspilerDataBuilder();
 
-    transpile(compilerUnit: CompilerUnit, config ?: TSTranspilerDataConfig): TSTranspilerData {
+    transpile(compilerUnit: CompilerUnit, api: TranspilerApi, config ?: TSTranspilerDataConfig): TSTranspilerData {
         createProgram(compilerUnit, createTranspilerOptions())
             .getSourceFiles()
             .filter(source => !source.isDeclarationFile)
@@ -27,6 +28,7 @@ export class TSTranspiler {
             .withPath(compilerUnit.path)
             .withInput(compilerUnit.content)
             .withConfig(config || new TSTranspilerDataConfig())
+            .withApi(api)
             .build();
     }
 

--- a/packages/compiler/src/transpiler/model.ts
+++ b/packages/compiler/src/transpiler/model.ts
@@ -213,7 +213,7 @@ export class ClassPropertyData {
                 readonly end: number) {
     }
 
-    static fromTsSource(property: ts.PropertyDeclaration, source: ts.SourceFile) : ClassPropertyData {
+    static fromTsSource(property: ts.PropertyDeclaration, source: ts.SourceFile): ClassPropertyData {
         return new ClassPropertyData(
             getIdentifier(property.name),
             property.getStart(source),
@@ -266,8 +266,20 @@ export class TSTranspilerClassData {
 export interface TSTranspilerData {
     input: string;
     path: string;
+    api: TranspilerApi;
     classList: Array<TSTranspilerClassData>;
     config: TSTranspilerDataConfig;
+}
+
+export class TranspilerApi {
+    constructor(public addDependency: (file: string) => void) {
+    }
+
+    static empty: TranspilerApi = new TranspilerApi(
+        (file: string) => {
+            // nothing to do here by default
+        }
+    );
 }
 
 export class TSTranspilerDataConfig {
@@ -280,6 +292,7 @@ export class TSTranspilerDataBuilder {
     private data: TSTranspilerData = {
         input: '',
         path: null,
+        api: TranspilerApi.empty,
         classList: [],
         config: {template: new CompilerTemplateConfig()}
     };
@@ -297,6 +310,11 @@ export class TSTranspilerDataBuilder {
 
     withConfig(value: TSTranspilerDataConfig): TSTranspilerDataBuilder {
         this.data.config = value;
+        return this;
+    }
+
+    withApi(value: TranspilerApi): TSTranspilerDataBuilder {
+        this.data.api = value;
         return this;
     }
 

--- a/packages/compiler/test/compiler.spec.ts
+++ b/packages/compiler/test/compiler.spec.ts
@@ -4,21 +4,21 @@ import {
     CompilerUnitTransformer,
     crateCompilationUnit,
     crateCompilerConfig,
-    SourceTransformation
+    SourceTransformation, TranspilerApi,
+    TSTranspilerData
 } from "../src";
-import {TSTranspilerData} from "../src/transpiler/model";
 
 describe('compiler spec', () => {
     it('should throw error if compiler config is null', () => {
-        expect(() => compile(crateCompilationUnitMock(), null)).toThrowError('[ng-alchemy][error] config can\'t be null!');
+        expect(() => compile(crateCompilationUnitMock(), null, TranspilerApi.empty)).toThrowError('[ng-alchemy][error] config can\'t be null!');
     });
 
     it('should throw error if compiler compilation unit is null', () => {
-        expect(() => compile(null, null)).toThrowError('[ng-alchemy][error] compilation unit can\'t be null!');
+        expect(() => compile(null, null, TranspilerApi.empty)).toThrowError('[ng-alchemy][error] compilation unit can\'t be null!');
     });
 
     it('should return same output if list of transformers are empty', () => {
-        const result = compile(crateCompilationUnitMock(), crateCompilerConfig());
+        const result = compile(crateCompilationUnitMock(), crateCompilerConfig(), TranspilerApi.empty);
 
         expect(result).toEqual(crateCompilationUnitMock().content);
     });
@@ -32,7 +32,7 @@ describe('compiler spec', () => {
                 return [new SourceTransformation(start, end, 'Bar')];
             }
         };
-        const result = compile(crateCompilationUnitMock(), crateCompilerConfig(transformer));
+        const result = compile(crateCompilationUnitMock(), crateCompilerConfig(transformer), TranspilerApi.empty);
 
         expect(result).toEqual('export class Bar {}');
     })

--- a/packages/compiler/test/transformer/component-transformer.spec.ts
+++ b/packages/compiler/test/transformer/component-transformer.spec.ts
@@ -1,13 +1,14 @@
-import {compile, ComponentTransformer, crateCompilationUnit, crateCompilerConfig} from "../../src";
+import {compile, ComponentTransformer, crateCompilationUnit, crateCompilerConfig, TranspilerApi} from "../../src";
 
 describe('ComponentTransformerTest', () => {
     it('should remove @Input and @Output and add bindings to component definition', () => {
-        const input: string  = `@Component({selector:'foo'}) class Foo { @Input() input : string; @Output() output : string;}`;
+        const input: string = `@Component({selector:'foo'}) class Foo { @Input() input : string; @Output() output : string;}`;
         const output: string = ` class Foo {  input : string;  output : string;static ngComponentDef:any = {selector:'foo',bindings:{input:'<',output:'&'},controller:Foo};}`;
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new ComponentTransformer())
+            crateCompilerConfig(new ComponentTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/generic-class-decorator-transformer.spec.ts
+++ b/packages/compiler/test/transformer/generic-class-decorator-transformer.spec.ts
@@ -1,4 +1,4 @@
-import {compile, crateCompilationUnit, crateCompilerConfig, update} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, TranspilerApi, update} from '../../src';
 import {GenericClassDecoratorTransformer} from "../../src/transformer";
 
 const generic = new GenericClassDecoratorTransformer(
@@ -13,7 +13,8 @@ describe('GenericClassDecoratorTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(generic)
+            crateCompilerConfig(generic),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -25,7 +26,8 @@ describe('GenericClassDecoratorTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(generic)
+            crateCompilerConfig(generic),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -37,7 +39,8 @@ describe('GenericClassDecoratorTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(generic)
+            crateCompilerConfig(generic),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/injectable-transformer.spec.ts
+++ b/packages/compiler/test/transformer/injectable-transformer.spec.ts
@@ -1,4 +1,4 @@
-import {compile, crateCompilationUnit, crateCompilerConfig, InjectableTransformer} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, InjectableTransformer, TranspilerApi} from "../../src";
 
 describe('InjectableTransformerTest', () => {
     it('should add name from type', function () {
@@ -7,7 +7,8 @@ describe('InjectableTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new InjectableTransformer())
+            crateCompilerConfig(new InjectableTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -19,7 +20,8 @@ describe('InjectableTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new InjectableTransformer())
+            crateCompilerConfig(new InjectableTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/ng-module-transformer.spec.ts
+++ b/packages/compiler/test/transformer/ng-module-transformer.spec.ts
@@ -1,4 +1,4 @@
-import {compile, crateCompilationUnit, crateCompilerConfig, NgModuleTransformer} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, NgModuleTransformer, TranspilerApi} from "../../src";
 
 describe('NgModuleTransformerTest', () => {
     it('should add static ngModule def and remove decorator', () => {
@@ -7,7 +7,8 @@ describe('NgModuleTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new NgModuleTransformer())
+            crateCompilerConfig(new NgModuleTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/ng1-component-transformer.spec.ts
+++ b/packages/compiler/test/transformer/ng1-component-transformer.spec.ts
@@ -1,4 +1,4 @@
-import {compile, crateCompilationUnit, crateCompilerConfig, Ng1ComponentTransformer} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, Ng1ComponentTransformer, TranspilerApi} from "../../src";
 
 describe('Ng1ComponentTransformerTest', () => {
     it('should remove @Input and @Output and add bindings to component definition', () => {
@@ -7,7 +7,8 @@ describe('Ng1ComponentTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1ComponentTransformer())
+            crateCompilerConfig(new Ng1ComponentTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -18,7 +19,8 @@ describe('Ng1ComponentTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1ComponentTransformer())
+            crateCompilerConfig(new Ng1ComponentTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -30,7 +32,8 @@ describe('Ng1ComponentTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1ComponentTransformer())
+            crateCompilerConfig(new Ng1ComponentTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/ng1-inject-transformer.spec.ts
+++ b/packages/compiler/test/transformer/ng1-inject-transformer.spec.ts
@@ -1,5 +1,4 @@
-import {compile} from "../../src";
-import {crateCompilationUnit, crateCompilerConfig} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, TranspilerApi} from "../../src";
 import {Ng1InjectTransformer} from "../../src/transformer";
 
 describe('Ng1InjectTransformerTest', () => {
@@ -9,7 +8,8 @@ describe('Ng1InjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectTransformer())
+            crateCompilerConfig(new Ng1InjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -41,7 +41,8 @@ describe('Ng1InjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectTransformer())
+            crateCompilerConfig(new Ng1InjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -73,7 +74,8 @@ describe('Ng1InjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectTransformer())
+            crateCompilerConfig(new Ng1InjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -93,7 +95,8 @@ describe('Ng1InjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectTransformer())
+            crateCompilerConfig(new Ng1InjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -113,7 +116,8 @@ describe('Ng1InjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectTransformer())
+            crateCompilerConfig(new Ng1InjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -133,7 +137,8 @@ describe('Ng1InjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectTransformer())
+            crateCompilerConfig(new Ng1InjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/ng1-injectable-transformer.spec.ts
+++ b/packages/compiler/test/transformer/ng1-injectable-transformer.spec.ts
@@ -1,5 +1,4 @@
-import {compile} from "../../src";
-import {crateCompilationUnit, crateCompilerConfig} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, TranspilerApi} from "../../src";
 import {Ng1InjectableTransformer} from "../../src/transformer";
 
 describe('Ng1InjectableTransformerTest', () => {
@@ -9,7 +8,8 @@ describe('Ng1InjectableTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectableTransformer())
+            crateCompilerConfig(new Ng1InjectableTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -21,7 +21,8 @@ describe('Ng1InjectableTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectableTransformer())
+            crateCompilerConfig(new Ng1InjectableTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -33,7 +34,8 @@ describe('Ng1InjectableTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1InjectableTransformer())
+            crateCompilerConfig(new Ng1InjectableTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transformer/ng1-static-inject-transformer.spec.ts
+++ b/packages/compiler/test/transformer/ng1-static-inject-transformer.spec.ts
@@ -1,5 +1,4 @@
-import {compile} from "../../src";
-import {crateCompilationUnit, crateCompilerConfig} from "../../src";
+import {compile, crateCompilationUnit, crateCompilerConfig, TranspilerApi} from "../../src";
 import {Ng1StaticInjectTransformer} from "../../src/transformer";
 
 describe('Ng1StaticInjectTransformerTest', () => {
@@ -25,7 +24,8 @@ describe('Ng1StaticInjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1StaticInjectTransformer())
+            crateCompilerConfig(new Ng1StaticInjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);
@@ -57,7 +57,8 @@ describe('Ng1StaticInjectTransformerTest', () => {
 
         const result = compile(
             crateCompilationUnit('Foo.ts', input),
-            crateCompilerConfig(new Ng1StaticInjectTransformer())
+            crateCompilerConfig(new Ng1StaticInjectTransformer()),
+            TranspilerApi.empty
         );
 
         expect(result).toEqual(output);

--- a/packages/compiler/test/transpiler.spec.ts
+++ b/packages/compiler/test/transpiler.spec.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import {CompilerUnit, crateCompilationUnit} from "../src";
+import {CompilerUnit, crateCompilationUnit, TranspilerApi} from "../src";
 import {TSTranspiler} from "../src/transpiler";
 import {
     ClassMethodData,
@@ -54,10 +54,11 @@ describe('transpiler spec', () => {
         }
         `;
 
-        const data = new TSTranspiler().transpile(crateCompilationUnitMock(file));
+        const data = new TSTranspiler().transpile(crateCompilationUnitMock(file), TranspilerApi.empty);
 
         expect(data).toEqual(new TSTranspilerDataBuilder()
             .withInput(file)
+            .withApi(TranspilerApi.empty)
             .addClass(new TSTranspilerClassData('TestService', 0, 60, undefined, []))
             .addClassDecorator(new DecoratorData('Injectable', [], '@Injectable()', 9, 22))
             .addClass(new TSTranspilerClassData('TestComponent', 60, 585, undefined, []))

--- a/packages/loader/index.ts
+++ b/packages/loader/index.ts
@@ -7,9 +7,9 @@ import {
     crateCompilationUnit,
     DecoratorData,
     Ng1StaticInjectTransformer,
-    SourceTransformation,
+    SourceTransformation, TranspilerApi,
     TSTranspilerClassData
-} from '../compiler';
+} from "../compiler";
 import {GenericClassDecoratorTransformer} from "../compiler/src/transformer";
 import {registerCompilerFileSystem} from "../compiler/src/filesystem";
 import {loader} from "webpack";
@@ -19,7 +19,8 @@ const registry: { [key: string]: CompilerConfig } = {};
 export default function loader(this: loader.LoaderContext, source: string): string {
     return compile(
         crateCompilationUnit(this.resourcePath, source, this.context),
-        getCompilerConfig(this.query)
+        getCompilerConfig(this.query),
+        new TranspilerApi(this.addDependency)
     )
 }
 


### PR DESCRIPTION
In case of angular component will use templateUrl in it's configuration then ng-alchemy loader would add this file as dependency. As a result on change template file webpack will reload page (or will try to use hmr if ng-alchemy is properly used in webpack dev server configuration).